### PR TITLE
Modify update_predict_normal() according to 7/08 notes

### DIFF
--- a/code/AnalyticsDataframe.py
+++ b/code/AnalyticsDataframe.py
@@ -1,7 +1,6 @@
 # Author: Fei
 import numpy as np
 from pandas import Series, DataFrame
-from scipy.linalg import cholesky
 
 
 class AnalyticsDataframe:
@@ -39,51 +38,44 @@ class AnalyticsDataframe:
         self.response_vector_name = response_vector_name
         self.response_vector = Series(np.random.rand(self.n), name=self.response_vector_name)
 
-    def update_predictor_normal(self, predictor_name_list: list = None, mean_dict: dict = None,
-                                std_dict: dict = None, correlation_matrix: np.ndarray = None):
+    def update_predictor_normal(self, predictor_name_list: list = None,
+                                mean: np.ndarray = None,
+                                covariance_matrix: np.ndarray = None):
         """
-        update_predictor_normal(self, predictor_name_list=None, mean_dict=None,
-                                std_dict=None, covariance_matrix=None)
-
+        update_predictor_normal(self, predictor_name_list=None, mean=None,
+                                covariance_matrix=None)
         Update the predictors of the instance to normally distributed.
         ------
         :param predictor_name_list: A list of predictor names in the initial AnalyticsDataframe
-        :param mean_dict: A dictionary,
-                        key: predictor name,
+        :param mean: A numpy array or list,
                         value: mean
-        :param std_dict: A dictionary,
-                        key: predictor name,
-                        value: standard deviation
-        :param correlation_matrix: A symmetric N * N matrix, defines correlation among N variables.
+        :param covariance_matrix: A symmetric and positive semi-definite N * N matrix,
+                                    defines correlation among N variables.
         :return:
         """
         col_nm = self.predictor_matrix.columns.values.tolist()
         if not set(predictor_name_list) <= set(col_nm):
             raise Exception(f'Please select the following predictors: {col_nm}')
 
-        # Check if update parameters have the same predictor name
-        def is_name_matched(name: list, mean: dict, var: dict):
-            return mean.keys() | set() == set(name) & mean.keys() == var.keys()
+        # Check if parameters have the same size
+        # for covariance matrix, it shall be symmetric and positive semi-definite
+        def _is_len_matched(_name: list, _mean: np.ndarray):
+            return len(_name) == len(_mean)
 
         # Update predictor data by mean and variance
-        if is_name_matched(predictor_name_list, mean_dict, std_dict) \
+        if _is_len_matched(predictor_name_list, mean) \
                 and len(predictor_name_list) > 0:
-            for col in predictor_name_list:
-                self.predictor_matrix[col] = np.random.normal(mean_dict[col], std_dict[col], self.n)
-        elif not is_name_matched(predictor_name_list, mean_dict, std_dict):
-            raise Exception(f'Unmatched inputs {predictor_name_list}, {mean_dict.keys()}, {std_dict.keys()} ')
+            num_row = len(self.predictor_matrix)
+            self.predictor_matrix[predictor_name_list] = np.random.multivariate_normal(mean,
+                                                                                       covariance_matrix,
+                                                                                       size=num_row,
+                                                                                       check_valid='warn')
 
-        # Use correlated matrix to update predictors
-        if correlation_matrix.any():
-            # Cholesky decomposition
-            c = correlation_matrix
-            u = cholesky(c)
-            # DataFrame of correlated random sequences
-            p_arr = self.predictor_matrix[predictor_name_list].to_numpy()
-            pc = p_arr @ u
-            self.predictor_matrix[predictor_name_list] = pc
+        elif not _is_len_matched(predictor_name_list, mean):
+            raise ValueError('predictor and mean must have same length')
 
 
+# initiate an AnalyticsDataframe with default name
 ad1 = AnalyticsDataframe(100, 5)
 print(ad1.predictor_matrix)
 #           X1        X2        X3        X4        X5
@@ -115,26 +107,57 @@ print(ad1.response_vector)
 # 99    0.709068
 # Name: Y, Length: 100, dtype: float64
 
-ad2 = AnalyticsDataframe(5, 3, ["xx1", "xx2", "xx3"], "yy")
-print(ad2.predictor_matrix)
-#         xx1       xx2       xx3
-# 0  0.282465  0.268106  0.506306
-# 1  0.654078  0.706370  0.110114
-# 2  0.922589  0.873792  0.071643
-# 3  0.135106  0.297225  0.859028
-# 4  0.894569  0.270150  0.416135
 
+##
+## Test case 1 - validate statistical properties of generated predictor matrix
+##
+ad2 = AnalyticsDataframe(10000, 3, ["xx1", "xx2", "xx3"], "yy")
 C = np.array([[1, -0.5, 0.3],
               [-0.5, 1, 0.2],
               [0.3, 0.2, 1]])
 ad2.update_predictor_normal(predictor_name_list=["xx1", "xx2", "xx3"],
-                            mean_dict={"xx1": 1, "xx2": 2, "xx3": 5},
-                            std_dict={"xx1": 0.5, "xx2": 1, "xx3": 1},
-                            correlation_matrix=C)
-print(ad2.predictor_matrix)
-#         xx1       xx2       xx3
-# 0  1.725309  0.235418  5.750566
-# 1  1.576663 -0.403526  5.401692
-# 2  1.230314  0.544714  5.885972
-# 3  0.295936  0.712885  4.858719
-# 4  1.457847  0.530003  4.571697
+                            mean=[1, 2, 5],
+                            covariance_matrix=C)
+test_matrix_1 = ad2.predictor_matrix
+print(test_matrix_1.mean())
+# xx1    1.003769
+# xx2    2.007161
+# xx3    5.008807
+
+print(test_matrix_1.corr())
+#           xx1       xx2       xx3
+# xx1  1.000000 -0.501385  0.300073
+# xx2 -0.501385  1.000000  0.203265
+# xx3  0.300073  0.203265  1.000000
+
+##
+## Test case 2 - Test handling of variable lists
+##
+
+ad3 = AnalyticsDataframe(100, 5)
+C = np.array([[1, -0.5, 0.3],
+              [-0.5, 1, 0.2],
+              [0.3, 0.2, 1]])
+
+
+# Should generate error due to mismatch of variable names
+#
+# ad3.update_predictor_normal(predictor_name_list=["xx1", "xx2", "xx3"],
+#                             mean=[1, 2, 5],
+#                             covariance_matrix=C)
+
+
+# Should generate error due to mismatch of shape between covariance and mean
+#
+# C2 = np.array([[1, -0.5],
+#               [-0.5, 1]])
+# ad3.update_predictor_normal(predictor_name_list=["X1", "X2", "X3"],
+#                             mean=[1, 2, 5],
+#                             covariance_matrix=C2)
+
+
+# Should generate error due to mismatch of shape between predictor and mean
+#
+# ad3.update_predictor_normal(predictor_name_list=["X1", "X2", "X3"],
+#                             mean=[1, 2],
+#                             covariance_matrix=C)

--- a/code/AnalyticsDataframe.py
+++ b/code/AnalyticsDataframe.py
@@ -143,7 +143,7 @@ print(test_matrix_1.corr())
 ## Test case 2 - Test handling of variable lists
 ##
 
-ad3 = AnalyticsDataframe(100, 5)
+ad3 = AnalyticsDataframe(100, 3)
 C = np.array([[1, -0.5, 0.3],
               [-0.5, 1, 0.2],
               [0.3, 0.2, 1]])

--- a/code/AnalyticsDataframe.py
+++ b/code/AnalyticsDataframe.py
@@ -154,6 +154,8 @@ C = np.array([[1, -0.5, 0.3],
 # ad3.update_predictor_normal(predictor_name_list=["xx1", "xx2", "xx3"],
 #                             mean=[1, 2, 5],
 #                             covariance_matrix=C)
+# ...
+# Exception: Please select the following predictors: ['X1', 'X2', 'X3']
 
 
 # Should generate error due to mismatch of shape between covariance and mean
@@ -163,6 +165,8 @@ C = np.array([[1, -0.5, 0.3],
 # ad3.update_predictor_normal(predictor_name_list=["X1", "X2", "X3"],
 #                             mean=[1, 2, 5],
 #                             covariance_matrix=C2)
+# ...
+# ValueError: mean and cov must have same length
 
 
 # Should generate error due to mismatch of shape between predictor and mean
@@ -170,3 +174,5 @@ C = np.array([[1, -0.5, 0.3],
 # ad3.update_predictor_normal(predictor_name_list=["X1", "X2", "X3"],
 #                             mean=[1, 2],
 #                             covariance_matrix=C)
+# ...
+# ValueError: predictor and mean must have same length


### PR DESCRIPTION
According to the notes from Prof. Wilcox on July 8, 2022, on slack.
> - For `update_predictor_normal` method, let's specify the `mean_dict` and `std_dict` as numpy arrays instead (must be specified in same order and be of same length as the predictor_name_list)

there is a new param called `mean` as numpy array instead of dict. And I removed `std_dict`, since it seems with covariance, we are able to determine the joint distribution.

> - Seems to be an error in the random data generation code (gives wrong means, stds, and correlations) 

I have substituted the `scipy.linag.Cholesky` function with `numpy.random.multivariate_normal`, which uses SVD. Now the generated data correlation matrix is matched with what we defined.